### PR TITLE
rspec_html/element: forwarding #css and #xpath

### DIFF
--- a/lib/rspec_html/element.rb
+++ b/lib/rspec_html/element.rb
@@ -8,7 +8,7 @@ module RSpecHTML
     extend Forwardable
 
     def_delegators :@search,
-                   :has_css?, :has_xpath?, :include?, :text, :truncated_text, :size, :length, :[]
+                   :has_css?, :has_xpath?, :include?, :text, :truncated_text, :size, :length, :css, :xpath, :[]
 
     def initialize(element, name, options: {}, siblings: [])
       @name = name


### PR DESCRIPTION
[xpath and css selectors](https://github.com/bobf/rspec-html#xpath--css-selectors) are mentioned in the docs and this PR makes them available as described